### PR TITLE
Make 1.8.6 the default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ None
 
 #### Variables
 
-* `vagrant_version` [default: `1.8.5`]: Version to install
+* `vagrant_version` [default: `1.8.6`]: Version to install
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 # defaults file for vagrant
 ---
-vagrant_version: 1.8.5
+vagrant_version: 1.8.6


### PR DESCRIPTION
See the [changelog](https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md)
